### PR TITLE
feat: adjust design to follow GNOME HIG

### DIFF
--- a/build-aux/dev.nordgedanken.heic2jpg.Devel.json
+++ b/build-aux/dev.nordgedanken.heic2jpg.Devel.json
@@ -1,11 +1,11 @@
 {
     "id": "dev.nordgedanken.heic2jpg.Devel",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable",
-        "org.freedesktop.Sdk.Extension.llvm16"
+        "org.freedesktop.Sdk.Extension.llvm18"
     ],
     "command": "heic2jpg",
     "finish-args": [
@@ -19,7 +19,7 @@
         "--env=RUST_BACKTRACE=1"
     ],
     "build-options": {
-        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm16/bin",
+        "append-path": "/usr/lib/sdk/rust-stable/bin:/usr/lib/sdk/llvm18/bin",
         "build-args": [
             "--share=network"
         ],

--- a/src/app.rs
+++ b/src/app.rs
@@ -155,6 +155,8 @@ impl SimpleComponent for App {
 
                                 gtk::Button {
                                     set_label: "Close",
+                                    add_css_class: "suggested-action",
+                                    add_css_class: "pill",
                                     connect_clicked[sender] => move |_| {
                                         sender.input(AppMsg::Quit);
                                     }
@@ -210,6 +212,8 @@ impl SimpleComponent for App {
                                 set_spacing: 24,
                                 gtk::Button {
                                     set_label: &gettext("Convert"),
+                                    add_css_class: "suggested-action",
+                                    add_css_class: "pill",
                                     connect_clicked[sender] => move |_| {
                                         sender.input(AppMsg::Convert);
                                     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -96,11 +96,9 @@ impl SimpleComponent for App {
                     None
                 },
 
-            gtk::Box {
-                set_orientation: gtk::Orientation::Vertical,
-                set_vexpand: true,
+            adw::ToolbarView {
 
-                adw::HeaderBar {
+               add_top_bar = &adw::HeaderBar {
                     #[wrap(Some)]
                     set_title_widget = &adw::WindowTitle {
                         set_title: &gettext("Convert Heic to JPG"),

--- a/src/select_folder.rs
+++ b/src/select_folder.rs
@@ -56,6 +56,8 @@ impl SimpleComponent for SelectFolder {
                 gtk::Button {
                     set_halign: gtk::Align::Center,
                     set_label: &model.button_label,
+                    add_css_class: "suggested-action",
+                    add_css_class: "pill",
                     connect_clicked[sender] => move |_| {
                         sender.input(SelectFolderMsg::OpenRequest);
                     }


### PR DESCRIPTION
Since the project uses libadwaita, I'm assuming the goal is to follow the [GNOME HIG](https://developer.gnome.org/hig/). I've slightly adjusted the design, to use suggested actions and [`Adw.ToolbarView`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.ToolbarView.html) to follow the HIG more closely.
Further improvements could include updating the pages to use [icons or illustrations](https://developer.gnome.org/hig/patterns/feedback/placeholders.html), adjusting the text.
You might want to take a look to at apps like [Switcheroo](https://flathub.org/apps/io.gitlab.adhami3310.Converter) or [Morphosis](https://flathub.org/apps/garden.jamie.Morphosis), which implement similar functionality.

![Updated folder selection](https://github.com/user-attachments/assets/b7474548-a408-4687-b30e-6f4bc1ac155e)
![Updated conversion screen](https://github.com/user-attachments/assets/1207a7c6-3843-4340-9912-4494a590b440)
